### PR TITLE
Example settings file, file modification detection, README 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,4 +241,8 @@ ModelManifest.xml
 # FAKE - F# Make
 .fake/
 
+# Visual Studio Code
+.vscode/
+
 build/
+edm-settings.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
 ﻿# edm-client
 
+## Building
+
+```
+npm install
+npm build
+```
+
+## Running
+```
+# npm start run
+cd build
+node app run -c ../edm-settings.json
+```
+
+## Auth setup
+
+Run edm-mock-auth server:
+```
+npm install
+npm start
+```
+
+Go to http://127.0.0.1:4000/auth - create an account.
+You can now stop the edm-mock-auth server.
+
+Grab the token for your client from the `edm_backend_dev` (or equivalent) database
+->`guardian_tokens` table, `jwt` field.
+
+Edit your edm-client config (eg `edm-settings.json`) and add the token to:
+ `{ "serverSettings": { "token": "blabla" }}`
+
+
+## TODO
+
 A list of small things to work on:
 
 * TODO: proxy settings parsing in edmKit/networking.ts, integrate with connection.ts

--- a/edm-settings.json.example
+++ b/edm-settings.json.example
@@ -1,0 +1,51 @@
+{
+  "sources": [
+    {
+      "name": "temptest",
+      "basepath": "/tmp/test-1",
+      "checkMethod": "cron",
+      "cronTime": "*/5 * * * * *",
+      "destinations": [
+        {
+          "host_id": "massive",
+          "location": "/home/test/test-1",
+          "exclusions": [
+            "*~"
+          ]
+        },
+        {
+          "host_id": "mytardis",
+          "location": "test-1-bucket"
+        }
+      ]
+    }
+  ],
+
+  "hosts": {
+     "massive": {
+         "transfer_method": "scp2",
+         "settings": {
+             "host": "massive.monash.edu",
+             "port": 22,
+             "username": "edm-tester",
+             "privateKey": "AAAABBBCCCCEEDSEFAEFAEFAEFwefaewf982y3fh9"
+         }
+     },
+     "mytardis": {
+         "transfer_method": "S3",
+         "settings": {
+             "EC2_ACCESS_KEY": "ABC123",
+             "EC2_SECRET_KEY": "CDE456"
+         }
+     }
+  },
+
+  "serverSettings": {
+    "host": "localhost:4000",
+    "connection": "poll, socket",
+    "interval": 5,
+    "token": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJDbGllbnQ6NzUyYjI5YjctODQyNC00YWYzLTgzNjQtNTg1MTkzZDY5MmRjIiwiZXhwIjoxNDgyNTMzODYwLCJpYXQiOjE0Nzk5NDE4NjAsImlzcyI6ImVkbS1iYWNrZW5kIiwianRpIjoiZTdkZTE3ZTYtNzRiNi00MzUzLTk3M2UtM2RlNWI4ZDE4M2NkIiwicGVtIjp7fSwic3ViIjoiQ2xpZW50Ojc1MmIyOWI3LTg0MjQtNGFmMy04MzY0LTU4NTE5M2Q2OTJkYyIsInR5cCI6InRva2VuIn0.DcL_yAnb2PAtZPSSFZ9VTCuwug-EIXuzlvjFc3ugFlRIi2BtKmA9xh8YwiE-eva2WixZ14kX2AlCVPdpP2rXjA"
+  },
+
+  "appSettings" : {}
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "Administrator"
   },
   "dependencies": {
+    "@types/npm": "^2.0.28",
     "apollo-client": "^0.4.19",
     "graphql": "^0.7",
     "graphql-tag": "^0.1.11",

--- a/src/app.ts
+++ b/src/app.ts
@@ -84,12 +84,18 @@ let args: yargs.Argv = yargs.usage("Usage: edm-client [options] action")
         describe: 'Location of your configuration file',
         type: 'string'
     })
-        .option('d', {
-            alias: 'data-dir',
-            demand: false,
-            describe: 'Data direcotry',
-            type: 'string'
-        })
+    .option('n', {
+        alias: 'ignore-server-config',
+        demand: false,
+        describe: "Don't allow server to override clientside configuration",
+        type: 'boolean'
+    })
+    .option('d', {
+        alias: 'data-dir',
+        demand: false,
+        describe: 'Data directory',
+        type: 'string'
+    })
     .option('s', {
         alias: 'server-address',
         demand: false,
@@ -99,7 +105,7 @@ let args: yargs.Argv = yargs.usage("Usage: edm-client [options] action")
     .option('t', {
         alias: 'token',
         demand: false,
-        describe: 'Optionally, specify acces token',
+        describe: 'Optionally, specify access token',
         type: 'string'
     })
     .help('h')
@@ -110,18 +116,27 @@ let argv = args.argv;
 let command: string = argv._[0];
 
 let initArgs = <EDMInitArgs>{};
-if (argv.hasOwnProperty("c") && typeof(argv["c"]) !== "undefined") {
-    initArgs.configFilePath = path.normalize(argv["c"]);
+
+function argIsSet(attr: string) : boolean {
+    return (argv.hasOwnProperty(attr) && (argv[attr] == null));
 }
-if (argv.hasOwnProperty("d") && typeof(argv["d"]) !== "undefined") {
-    initArgs.dataDir = path.normalize(argv["d"]);
+
+function getArg(attr: string, applyFn = undefined, defaultValue: any = undefined) : any {
+    if (argIsSet(attr)) {
+        defaultValue = argv[attr];
+    }
+    if (applyFn && typeof(defaultValue) !== "undefined") {
+        return applyFn(defaultValue);
+    } else {
+        return defaultValue;
+    }
 }
-if (argv.hasOwnProperty("s") && typeof(argv["s"]) !== "undefined") {
-    initArgs.serverAddress = path.normalize(argv["s"]);
-}
-if (argv.hasOwnProperty("t") && typeof(argv["t"]) !== "undefined") {
-    initArgs.token = path.normalize(argv["t"]);
-}
+
+initArgs.configFilePath = getArg("c", path.normalize);
+initArgs.ignoreServerConfig = getArg("n");
+initArgs.dataDir = getArg("d", path.normalize);
+initArgs.serverAddress = getArg("s");
+initArgs.token = getArg("t");
 
 settings.parseInitArgs(initArgs);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -118,14 +118,14 @@ let command: string = argv._[0];
 let initArgs = <EDMInitArgs>{};
 
 function argIsSet(attr: string) : boolean {
-    return (argv.hasOwnProperty(attr) && (argv[attr] == null));
+    return (argv.hasOwnProperty(attr) && (argv[attr] != null));
 }
 
 function getArg(attr: string, applyFn = undefined, defaultValue: any = undefined) : any {
     if (argIsSet(attr)) {
         defaultValue = argv[attr];
     }
-    if (applyFn && typeof(defaultValue) !== "undefined") {
+    if (applyFn && defaultValue != null) {
         return applyFn(defaultValue);
     } else {
         return defaultValue;

--- a/src/edmKit/connection.ts
+++ b/src/edmKit/connection.ts
@@ -11,9 +11,6 @@ import {createNetworkInterface, default as ApolloClient} from "apollo-client";
 export class EDMConnection extends ApolloClient {
 
     constructor(host: string, token: string) {
-        token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJDbGllbnQ6ODY1ZDBlMGYtYjM5NS00MzAyLTliZDgtNDAzZTAxODAxNmEyIiwiZXhwIjoxNDc5OTU2OTM1LCJpYXQiOjE0NzczNjQ5MzUsImlzcyI6ImVkbS1iYWNrZW5kIiwianRpIjoiNDkwY2FiN2EtM2E5MC00ODdhLWIzMGQtYWQxNmQwOGVhM2U2IiwicGVtIjp7fSwic3ViIjoiQ2xpZW50Ojg2NWQwZTBmLWIzOTUtNDMwMi05YmQ4LTQwM2UwMTgwMTZhMiIsInR5cCI6InRva2VuIn0.LW5Ynprc5MwabHn2FRZcssou8D9R5QUDHMKzGjc4Ldjs7MZO8trOgIB1-SXX1WH7MIfJE9KfnMadHONE121OZw";
-        token = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJDbGllbnQ6ZDM4ZmYzMWEtMGU2OC00NWVkLTg4ZWEtMGM0MDk2NjQwYWM5IiwiZXhwIjoxNDgwMDQ5MjY4LCJpYXQiOjE0Nzc0NTcyNjgsImlzcyI6ImVkbS1iYWNrZW5kIiwianRpIjoiNTY4N2M5ODgtNWEwNy00NjIyLWFkZGQtMTMxNzA0OGM2YjBlIiwicGVtIjp7fSwic3ViIjoiQ2xpZW50OmQzOGZmMzFhLTBlNjgtNDVlZC04OGVhLTBjNDA5NjY0MGFjOSIsInR5cCI6InRva2VuIn0.wXevW6L2z2B4tlpYu2zslnyauC6x6oA3QX3FUKDfBZ6EjDlWYsqANZWhINhQdRXUaO7adIi2yEBwtzg3ei4X8Q";
-        token = "eyJraW5kIjoiQWNjZXNzVG9rZW4iLCJqdGkiOiJlYzc3NGQ4Yy0zMWU1LTQ1OTgtYTM5ZC0zZmIxZjMzYmNiOGIiLCJpYXQiOjE0NzkwOTMyNTUsImV4cCI6MTQ3OTEwMDQ1NSwiaXNzIjoiaHR0cDovLzEyNy4wLjAuMTo1MDAwL29wIn0.sHPRPRe3ZssEbRfarchykv1tHTJGplwEoUhj54-EJuCiI8Imt4YMn5eNYK54NYyTC0OzUwSUmcnCt09JIhloYIFH3a6nublFVobwQZyuwS77m056wbzIGgYICfJsZG2g4c_5MqjITP9KOTnWqrIlWiXCXGoFtrBnmH2KtBe71KNj8TiANx9jd7sOcx0jce6ohchV-rqdxsBXqBEuZKbKu7PCUCI38mXAcv_deJ_sQLl8AD1RMiBQJQoqFfidxty2myMStFTY9rVmaIp1qh55N3X4U-ZRpml4LfCj7p9xahYn1REiE9ARqNX8WjXM6LAlGgVj_zNF_gD7KkUtWjdzqGLXErCpeUVxV5nzoMwUc4BXocd7P5VGEFK-OOeRRKLfSM85g2GZC8_kfv4-EykpunxK4SUztm5pBrKijpDmYaSnCCz8a9vJASxVP2DqGAQbSDFu-s6LuSXnKsW4-yyxwoZ0xpBD_on4XQuo4O_s8X1d0RSEnrg7KcnVls-1-4oLr4jrBU6nhd_hYH0awFoUQ_LYkHrkcxljVwFDp6HLmf0IRKx-XASih4g6AlPdg1kz2Dastbpnej2u1vrDbQk2PX3mvHvBnGQW9_gtfrm9vomAtiPZPn3fldJ4Ju7ZoGEVw8t0Zo_lPiDvvWOSaf9cRoi6tNI4ra3u2RSKFncjvMw";
         const graphqlEndpoint = `http://${host}/api/v1/graphql`;
         const networkInterface = createNetworkInterface(graphqlEndpoint);
         networkInterface.use([{
@@ -22,6 +19,9 @@ export class EDMConnection extends ApolloClient {
                     req.options.headers = {};
                 }
                 req.options.headers["authorization"] = `Bearer ${token}`;
+                // TODO: Set proxy for requests
+                //req.options.host = systemProxy.host;
+                //req.options.port = systemProxy.port;
                 next();
             }
         }]);

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -86,11 +86,14 @@ export class EDMFileCache {
             }
           }
         }`).then((result) => {
-            this.updateEntry(doc, {status: result.data.status});
+            // if server says never seen it,
+            // update EDMFileCached in db to status = 'new'
+            this.updateStatus(doc, result.data.status);
         });
     }
 
-    private updateEntry(doc: any, updates: {status: any}) {
-
+    private updateStatus(doc: any, status: string) {
+        doc.status = status;
+        this.db.put(doc);
     }
 }

--- a/src/lib/file_tracking.ts
+++ b/src/lib/file_tracking.ts
@@ -50,20 +50,24 @@ export default class EDMFile {
         this.basepath = basepath;
         this.filepath = filepath;
         this._id = filepath;
-        if (typeof stats === "undefined")
+        if (stats == null) {
             this.updateStats();
-        else
+        }
+        else {
             this.stats = stats;
+            this._computeHash();
+        }
     }
 
-    _computeHash() {
-        const data = `${this.filepath}|${this.stats.size}|${this.stats.mtime.getTime()}`;
-        this.hash = Buffer.from(data).toString('base64');
+    private _computeHash() {
+        const format = 'psm';
+        const hash = `${this.filepath}-${this.stats.size}-${this.stats.mtime.getTime()}`;
+        this.hash = `urn:${format}:${hash}`;
     }
 
     updateStats() {
         this.stats = fs.statSync(path.resolve(this.basepath, this.filepath));
-        // this._computeHash();  // may not be needed
+        this._computeHash();  // may not be needed
     }
 
     getPouchDocument() {
@@ -72,6 +76,7 @@ export default class EDMFile {
             mtime: this.stats.mtime.getTime(),
             size: this.stats.size,
             status: this.status,
+            hash: this.hash,
         };
     }
 }

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -73,9 +73,11 @@ query MeQuery {
                 print_json(settings);
                 print_json(clientInfo.sources);
                 this.stop();
-                settings.parseConfigObject({
-                    sources: clientInfo.sources,
-                    hosts: clientInfo.hosts});
+                if (!settings.conf.appSettings.ignoreServerConfig) {
+                    settings.parseConfigObject({
+                        sources: clientInfo.sources,
+                        hosts: clientInfo.hosts});
+                }
                 this.setUp();
                 print_json(settings.conf);
             },
@@ -91,9 +93,7 @@ query MeQuery {
     }
 
     setUp() {
-        const sources = settings.conf.sources;
-        for (let id in settings.conf.sources) {
-            const source = settings.conf.sources[id];
+        for (let source of settings.conf.sources) {
             switch(source.checkMethod) {
                 case "cron":
                     this.startWatcher(source);
@@ -101,6 +101,7 @@ query MeQuery {
                 case "fsnotify":
                     break;
                 case "manual":
+                    break;
                 default:
                     break;
             }
@@ -124,6 +125,7 @@ query MeQuery {
             start: true,
         });
         this.tasks.push(job);
+        console.log(`Starting file watcher on ${source.basepath}`)
     }
 
     private stop() {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -17,22 +17,25 @@ export class EDMSettings {
         this.conf.serverSettings = {};
     }
 
-    parseConfigObject(conf: Object) {
+    parseConfigObject(parsedConf: Object) {
         // const sections = [
         //     "sources", "endpoints",
         //     "serverSettings", "appSettings"];
-        for (let section in ["appSettings", "serverSettings"]) {
-            for (let entry in conf[section]) {
-                this.conf[section][entry] = conf[section][entry];
+        for (let section of ['appSettings', 'serverSettings']) {
+            for (let entry in parsedConf[section]) {
+                this.conf[section][entry] = parsedConf[section][entry];
             }
         }
-        this.conf.sources = [];
-        for (let source of conf["sources"]) {
+        if (this.conf.sources == null) this.conf.sources = [];
+        for (let source of parsedConf['sources']) {
             this.conf.sources.push(source);
         }
-        this.conf.hosts = {};
-        for (let host of conf["hosts"]) {
-            this.conf.hosts[host.id] = host;
+
+        if (this.conf.hosts == null) this.conf.hosts = {};
+        let hosts = parsedConf['hosts'];
+        for (let host in hosts) {
+            let value = hosts[host];
+            this.conf.hosts[host] = value;
         }
     }
 
@@ -64,7 +67,7 @@ export class EDMSettings {
         // initialise serverSettings
         this.conf.serverSettings = <ServerSettings>{};
         // first load configuration file
-        if (typeof initArgs.configFilePath !== "undefined")
+        if (initArgs.configFilePath != null)
             if (fs.existsSync(initArgs.configFilePath))
                 // use specified config file
                 this.readConfigFile(path.normalize(initArgs.configFilePath));
@@ -79,6 +82,8 @@ export class EDMSettings {
                           EDMSettings.default_config_file_name));
         }
 
+        this.conf.appSettings.ignoreServerConfig = initArgs.ignoreServerConfig;
+
         // then override some settings if specified
         this.conf.appSettings.dataDir = initArgs.dataDir ||
             this.conf.appSettings.dataDir || ospath.data(EDMSettings.app_name);
@@ -87,7 +92,9 @@ export class EDMSettings {
         this.conf.serverSettings.host = initArgs.serverAddress ||
             this.conf.serverSettings.host || "localhost:4000";
 
-        this.conf.serverSettings.token = initArgs.token;
+        if (initArgs.token != null) {
+            this.conf.serverSettings.token = initArgs.token;
+        }
     }
 
     private ensureDataDirExists() {
@@ -98,51 +105,3 @@ export class EDMSettings {
 }
 
 export const settings = new EDMSettings();
-
-
-// examples:
-// "sources": [
-//     {
-//         "basepath": "/tmp/test-1",
-//         "checkMethod": "watch, check, manual",
-//         "checkInterval": 5,
-//         "destinations": [
-//             {
-//                 "endpoint": "massive",
-//                 "location": "/home/test/test-1",
-//                 "exclusions": ["*~"]
-//             },
-//             {
-//                 "endpoint": "store.monash",
-//                 "location": "test-1-bucket"
-//             }
-//         ]
-//     }
-// ]
-//
-// "hosts": {
-//     "massive": {
-//         "transfer_method": "scp2",
-//         "settings": {
-//             "host": "massive.monash.edu",
-//             "port": 22,
-//             "username": "edm-tester",
-//             "privateKey": "AAAABBBCCCCEEDSEFAEFAEFAEFwefaewf982y3fh9"
-//         }
-//     },
-//     "mytardis": {
-//         "transfer_method": "S3",
-//         "settings": {
-//             "EC2_ACCESS_KEY": "ABC123",
-//             "EC2_SECRET_KEY": "CDE456"
-//         }
-//     }
-// }
-//
-// "serverSettings": {
-//     "host": "localhost:4000",
-//     "connection": "poll, socket",
-//     "interval": 5
-// }
-//
-// "appSettings": {}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,6 +4,7 @@ interface EDMInitArgs {
     token?: string,
     configFilePath?: string,
     dataDir?: string,
+    ignoreServerConfig?: boolean;
 }
 
 interface ServerSettings {
@@ -15,6 +16,7 @@ interface ServerSettings {
 
 interface AppSettings {
     dataDir?: string;
+    ignoreServerConfig?: boolean;
 }
 
 interface Settings {
@@ -25,9 +27,20 @@ interface Settings {
     sources?: any;
 }
 
+type FileStatus =
+    "unknown"
+    | "new"
+    | "modified"
+    | "verifying"
+    | "uploading"
+    | "interrupted"
+    | "uploaded";
+
 interface EDMCachedFile {
-    _id: string;  // file path
+    _id: string;   // file path
+    _rev?: string; // PouchDB revision
     mtime: number;
     size: number;
-    status: string;
+    status: FileStatus;
+    hash: string;
 }


### PR DESCRIPTION
This PR adds:
- detection of modified files by the file watcher
- an example local settings file
- development setup instructions to the README
- small refactoring of commandline arg handling
- adds commandline option to ignore any config sent by the server (convenience option for development, my be removed / hidden in the future)
- changes many instances of `(typeof someVar === "undefined")` to `someVar == null`, which catches both `undefined` and `null` variables more concisely (via type coercion).
