### PR TITLE
Fix GQL to match new backend mutation name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,4 +245,5 @@ ModelManifest.xml
 .vscode/
 
 build/
+src/**/*.js
 edm-settings.json

--- a/src/lib/file_watcher.ts
+++ b/src/lib/file_watcher.ts
@@ -116,14 +116,14 @@ export class EDMFileWatcher {
         return EDMQueries.registerFileWithServer(localFile, this.source.name, this.client)
             .then((backendResponse) => {
                 const transfers = _.get(
-                    backendResponse.data.getOrCreateFile.file, 'file_transfers', []);
+                    backendResponse.data.createOrUpdateFile.file, 'file_transfers', []);
                 let doc: EDMCachedFile = localFile.getPouchDocument();
                 if (cachedRecord != null) { // we are updating an existing record
                     doc._id = cachedRecord._id;
                     doc._rev = cachedRecord._rev;
                 }
                 doc.transfers = transfers;
-                this.cache.db.put(doc).error((error) => {
+                this.cache.db.put(doc).catch((error) => {
                     console.error(`Cache put failed: ${error}`);
                 });
                 // console.log(backendResponse);

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -22,43 +22,28 @@ export class EDMQueries {
                     }`;
     }
 
-    public static getOrCreateFileMutation(file: EDMFile,
-                                  source_name: string,
-                                  mutation_id?: string) : MutationOptions {
+    public static createOrUpdateFile(
+        file: EDMFile,
+        source_name: string,
+        mutation_id?: string) : MutationOptions {
 
-        // TODO: Not yet supported by backend, but this is what we'd use
-        //       Query to determine if a file needs to be transferred.
-        //       Also returns some file stats to store in local PouchDB.
-        //       We don't return atime, ctime, birthtime, mode (or hash)
-        //       since these aren't (yet) stored in the local cache.
-        // const mutation = gql`
-        // mutation getOrCreateFile($input: GetOrCreateFileInput!) {
-        //  getOrCreateFile(input: $input) {
-        //     clientMutationId
-        //     file {
-        //       filepath
-        //       size
-        //       mtime
-        //       file_transfers {
-        //           transfer_status
-        //           bytes_transferred
-        //           destination {
-        //               host_id
-        //           }
-        //       }
-        //     }
-        //  }
-        // }`;
         if (mutation_id == null) {
             mutation_id = uuidV4();
         }
 
         const mutation = gql`
-        mutation getOrCreateFile($input: GetOrCreateFileInput!) {
-         getOrCreateFile(input: $input) {
+        mutation createOrUpdateFile($input: CreateOrUpdateFileInput!) {
+         createOrUpdateFile(input: $input) {
             clientMutationId
             file {
-              filepath
+                filepath
+                file_transfers {
+                    status
+                    bytes_transferred
+                    destination {
+                        host_id
+                    }
+                }
             }
          }
         }`;
@@ -82,15 +67,15 @@ export class EDMQueries {
                                   connection: EDMConnection,
                                   mutation_id?: string): Promise<ApolloQueryResult> {
 
-        const mutation = EDMQueries.getOrCreateFileMutation(
+        const mutation = EDMQueries.createOrUpdateFile(
             file,
             source_name,
             mutation_id);
 
         return connection.mutate(mutation);
             // .then((value) => {
-            //     // console.log(JSON.stringify(value));
-            //     return value;
+            //         console.log(JSON.stringify(value));
+            //         return value;
             // });
     }
 }

--- a/src/test/test_file_watcher.ts
+++ b/src/test/test_file_watcher.ts
@@ -52,7 +52,7 @@ describe("file watcher", function () {
         tmpFile = createNewTmpfile();
         replyData = {
             "data": {
-                "getOrCreateFile": {
+                "createOrUpdateFile": {
                     "clientMutationId": mutation_id,
                     "file": {
                         "filepath": tmpFile,
@@ -75,12 +75,12 @@ describe("file watcher", function () {
         prepareForGqlRequest();
         tmpFile = createNewTmpfile();
         let watcher = new EDMFileWatcher({'basepath': dirToIngest});
-        const edmFile = new EDMFile(dirToIngest, path.basename(tmpFile));
+        const edmFile: EDMFile = new EDMFile(dirToIngest, path.basename(tmpFile));
         watcher.registerAndCache(edmFile)
             .then((backendResponse) => {
                 watcher.cache.getEntry(edmFile)
                     .then((doc) => {
-                        const expected = replyData.data.getOrCreateFile.file.file_transfers;
+                        const expected = replyData.data.createOrUpdateFile.file.file_transfers;
                         expect(doc.transfers[0].transfer_status).to.equal(expected[0].transfer_status);
                         expect(doc.transfers[1].transfer_status).to.equal(expected[1].transfer_status);
                         console.log(doc);

--- a/src/test/test_service.ts
+++ b/src/test/test_service.ts
@@ -27,7 +27,7 @@ describe("A mock EDM backend service", function () {
 
         expectedReplyData = {
             "data": {
-                "getOrCreateFile": {
+                "createOrUpdateFile": {
                     "clientMutationId": mutation_id,
                     "file": {
                         "filepath": tmpFile.name,


### PR DESCRIPTION
Brings client in sync with current backend API.
Small bugfix for PouchDB put error handling (catch rather than error method on Promise).